### PR TITLE
Add `dunfell` to the LAYERSERIES_COMPACT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILE_COLLECTIONS += "parsec-layer"
 BBFILE_PATTERN_parsec-layer = "^${LAYERDIR}/"
 BBFILE_PRIORITY_parsec-layer = "10"
 
-LAYERSERIES_COMPAT_parsec-layer = "gatesgarth"
+LAYERSERIES_COMPAT_parsec-layer = "dunfell gatesgarth"
 
 LAYERDEPENDS_parsec-layer = "core rust-layer clang-layer tpm-layer"
 BBLAYERS_LAYERINDEX_NAME_parsec-layer = "meta-parsec"


### PR DESCRIPTION
otherwise bitbake throws error - Layer parsec-layer is not
compatible with the core layer which only supports these series: dunfell