### PR TITLE
Updated swtpm and parsec service unit file

### DIFF
--- a/recipes-parsec/parsec-service/parsec-service.inc
+++ b/recipes-parsec/parsec-service/parsec-service.inc
@@ -24,9 +24,12 @@ do_install_append () {
 
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${S}/systemd-daemon/parsec.service ${D}${systemd_unitdir}/system
-    sed -i -e 's,ExecStart=/usr/libexec/parsec/parsec,ExecStart=/bin/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
+    sed -i -e 's,ExecStart=/usr/libexec/parsec/parsec,ExecStart=/usr/bin/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,WorkingDirectory=/home/parsec/,WorkingDirectory=/userdata,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=/bin/sleep 10,g' ${D}${systemd_unitdir}/system/parsec.service
+    sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=mkdir -p /tmp/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
+    sed -i -e 's,\[Service\],\[Service\]\nRestartSec=5s,g' ${D}${systemd_unitdir}/system/parsec.service
+    sed -i -e 's,\[Service\],\[Service\]\nRestart=always,g' ${D}${systemd_unitdir}/system/parsec.service
 
     parsec_configure ${D}${sysconfdir}/parsec/config.toml
 }

--- a/recipes-parsec/parsec-service/parsec-service/config.toml
+++ b/recipes-parsec/parsec-service/parsec-service/config.toml
@@ -1,6 +1,6 @@
 [core_settings]
 # The CI already timestamps the logs
-log_timestamp = false
+log_level = "trace"
 log_error_details = true
 
 # The container runs the Parsec service as root, so make sure we disable root
@@ -12,10 +12,10 @@ listener_type = "DomainSocket"
 # The timeout needs to be smaller than the test client timeout (five seconds) as it is testing
 # that the service does not hang for very big values of body or authentication length.
 timeout = 3000 # in milliseconds
-socket_path = "/tmp/parsec.sock"
+socket_path = "/tmp/parsec/parsec.sock"
 
 [authenticator]
-auth_type = "Direct"
+auth_type = "UnixPeerCredentials"
 
 [[key_manager]]
 name = "on-disk-manager"

--- a/recipes-swtpm/swtpm-service/swtpm-service/swtpm.service
+++ b/recipes-swtpm/swtpm-service/swtpm-service/swtpm.service
@@ -3,8 +3,10 @@ Description=SWTPM
 Before=parsec.service
 
 [Service]
+Restart=always
+RestartSec=5s
 WorkingDirectory=/userdata
-ExecStart=/bin/tpm_server
+ExecStart=/usr/bin/tpm_server
 
 [Install]
 WantedBy=default.target

--- a/recipes-swtpm/swtpm-service/swtpm-service/swtpm_changeauth.service
+++ b/recipes-swtpm/swtpm-service/swtpm-service/swtpm_changeauth.service
@@ -6,7 +6,7 @@ After=swtpm_tpm_startup.service
 [Service]
 WorkingDirectory=/userdata
 ExecStartPre=/bin/sleep 6
-ExecStart=-/bin/tpm2_changeauth -c owner tpm_pass
+ExecStart=-/usr/bin/tpm2_changeauth -c owner tpm_pass
 
 [Install]
 WantedBy=swtpm.service

--- a/recipes-swtpm/swtpm-service/swtpm-service/swtpm_startup.service
+++ b/recipes-swtpm/swtpm-service/swtpm-service/swtpm_startup.service
@@ -6,7 +6,7 @@ After=swtpm.service
 [Service]
 WorkingDirectory=/userdata
 ExecStartPre=/bin/sleep 5
-ExecStart=/bin/tpm2_startup -c -T mssim
+ExecStart=/usr/bin/tpm2_startup -c -T mssim
 
 [Install]
 WantedBy=swtpm.service


### PR DESCRIPTION
1. In Yocto, software TPM, parsec and related tools are installed in /usr/bin.
1. Updated the Parsec config file to create parsec.sock in /tmp/parsec folder.
1. Added Restart derivates to IBM SW TPM and Parsec. They should keep trying until
provisioning is performed.

I have tested these on RPi, I am hoping the same works on LmP OS as well.