### PR TITLE
Change folder permissions

### DIFF
--- a/recipes-swtpm/swtpm-service/swtpm-service/swtpm.service
+++ b/recipes-swtpm/swtpm-service/swtpm-service/swtpm.service
@@ -9,7 +9,7 @@ Restart=always
 RestartSec=5s
 WorkingDirectory=/userdata
 ExecStartPre=+mkdir -m 0700 -p /userdata/parsec
-ExecStartPre=+chown parsec:parsec /userdata/parsec
+ExecStartPre=+chown parsec /userdata/parsec
 ExecStart=/usr/bin/swtpm.sh
 ExecStop=/bin/tpm2_shutdown -T mssim
 


### PR DESCRIPTION
The parsec group doesn't get added after a software upgrade.
The folder is protected to the parsec user so the group is not used.