### PR TITLE
Set the parsec sock directory permission to 0755

### DIFF
--- a/recipes-parsec/parsec-service/parsec-service.inc
+++ b/recipes-parsec/parsec-service/parsec-service.inc
@@ -33,7 +33,7 @@ do_install_append () {
     install -m 0644 ${S}/systemd-daemon/parsec.service ${D}${systemd_unitdir}/system
 
     sed -i -e 's,WorkingDirectory=/home/parsec/,WorkingDirectory=/userdata/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
-    sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=mkdir -m 0700 -p /run/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
+    sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=mkdir -m 0755 -p /run/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nRestartSec=5s,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nRestart=always,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nUser=parsec,g' ${D}${systemd_unitdir}/system/parsec.service

--- a/recipes-parsec/parsec-service/parsec-service.inc
+++ b/recipes-parsec/parsec-service/parsec-service.inc
@@ -33,7 +33,7 @@ do_install_append () {
     install -m 0644 ${S}/systemd-daemon/parsec.service ${D}${systemd_unitdir}/system
 
     sed -i -e 's,WorkingDirectory=/home/parsec/,WorkingDirectory=/userdata/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
-    sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=mkdir -m 0755 -p /run/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
+    sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=mkdir -m 0750 -p /run/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nRestartSec=5s,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nRestart=always,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nUser=parsec,g' ${D}${systemd_unitdir}/system/parsec.service


### PR DESCRIPTION
This is required so that users which are part of the group=parsec
are able to access the sock. Also its the recommended permission level - https://parallaxsecond.github.io/parsec-book/parsec_service/install_parsec_linux.html#from-an-admin-user-with-privileges 