### PR TITLE
Add pkcs11 provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ meta-parsec layer
 ==============
 
 
-This layer contains recipes for the Parsec service with a software TPM provider service.
+This layer contains recipes for the Parsec service with either a software TPM or a PKCS11 provider service.
 
-Password
+
+Software TPM Password
 ============
 
 By default both the parsec and software TPM are configured to use the password **tpm_pass**  
@@ -35,6 +36,22 @@ To restart them:
 1. Start the parsec service  
 ```sudo systemctl start parsec```
 
+PKCS11 Pin
+============
+
+By default both the parsec and PKCS11 are configured to use the pins **12345678** and **87654321**  
+This **MUST** be changed as part of the factory setup process.  
+
+To change this perform the following steps:
+1. Stop the parsec service  
+```sudo systemctl stop parsec```
+1. Change the User pin  
+```sudo pkcs11-tool --module /usr/lib/libsks.so.0 --change-pin 87654321 --new-pin new_user_pin```
+1. Change the Security Officer pin  
+```sudo pkcs11-tool --module /usr/lib/libsks.so.0 --login --login-type so --so-pin 12345678 --change-pin --new-pin new_so_pin```
+1. Edit the parsec configuration file in ```/etc/parsec/config.toml``` and change the user_pin line to your new_user_pin.
+1. Restart the parsec service
+```sudo systemctl start parsec```
 
 
 
@@ -90,14 +107,5 @@ other layers needed. e.g.:
       /path/to/yocto/meta-security/meta-tpm \
       /path/to/yocto/meta-security/meta-parsec \
       "
-
-To include the Parsec service into your image add the following into the
-local.conf:
-
-    IMAGE_INSTALL_append = " parsec-service-tpm"
-    IMAGE_INSTALL_append = " parsec-tool"
-    IMAGE_INSTALL_append = " swtpm-service"
-
-The Parsec service will be deployed into the image with a config file for the software TPM provider.
 
 

--- a/recipes-parsec/parsec-service/files/pkcs11_1.patch
+++ b/recipes-parsec/parsec-service/files/pkcs11_1.patch
@@ -1,0 +1,26 @@
+diff --git a/src/providers/pkcs11/key_management.rs b/src/providers/pkcs11/key_management.rs
+index 6bc5e06..47d2f1a 100644
+--- a/src/providers/pkcs11/key_management.rs
++++ b/src/providers/pkcs11/key_management.rs
+@@ -121,6 +121,8 @@ impl Provider {
+ 
+         let mech = match key_attributes.key_type {
+             Type::RsaKeyPair => {
++                pub_template.push(Attribute::Class(ObjectClass::PUBLIC_KEY));
++                priv_template.push(Attribute::Class(ObjectClass::PRIVATE_KEY));
+                 pub_template.push(Attribute::Private(false.into()));
+                 pub_template.push(Attribute::PublicExponent(utils::PUBLIC_EXPONENT.into()));
+                 pub_template.push(Attribute::ModulusBits(
+diff --git a/src/providers/pkcs11/utils.rs b/src/providers/pkcs11/utils.rs
+index e83b522..e55c430 100644
+--- a/src/providers/pkcs11/utils.rs
++++ b/src/providers/pkcs11/utils.rs
+@@ -90,7 +90,7 @@ pub fn key_pair_usage_flags_to_pkcs11_attributes(
+     priv_template.push(Attribute::Decrypt((usage_flags.decrypt).into()));
+     priv_template.push(Attribute::Derive((usage_flags.derive).into()));
+     priv_template.push(Attribute::Extractable((usage_flags.export).into()));
+-    priv_template.push(Attribute::Sensitive((usage_flags.export).into()));
++    priv_template.push(Attribute::Sensitive((!usage_flags.export).into()));
+     priv_template.push(Attribute::Copyable((usage_flags.copy).into()));
+     pub_template.push(Attribute::Copyable((usage_flags.copy).into()));
+ }

--- a/recipes-parsec/parsec-service/parsec-service-pkcs11_0.7.2.bb
+++ b/recipes-parsec/parsec-service/parsec-service-pkcs11_0.7.2.bb
@@ -1,10 +1,10 @@
-# Parsec service with TPM provider
+# Parsec service with PKCS11 provider
 
-CARGO_EXTRA_FLAGS = "--features=tpm-provider"
+CARGO_EXTRA_FLAGS = "--features=pkcs11-provider"
 
 # Only 2.3.2 is available in the meta-security layer atm
 DEPENDS += "tpm2-tss"
-RDEPENDS_${PN} += "tpm2-tss"
+RDEPENDS_${PN} += " optee-sks opensc"
 
 require parsec-service.inc
 require parsec-service_${PV}.inc

--- a/recipes-parsec/parsec-service/parsec-service.inc
+++ b/recipes-parsec/parsec-service/parsec-service.inc
@@ -7,7 +7,10 @@ inherit cargo update-rc.d systemd
 TOOLCHAIN = "clang"
 
 SRC_URI += "crate://crates.io/parsec-service/${PV} \
-            file://config.toml \
+            ${@bb.utils.contains('PARSEC_PROVIDER','SOFTWARE_TPM','file://config-tpm.toml','',d)} \
+            ${@bb.utils.contains('PARSEC_PROVIDER','PKCS11','file://config-pkcs11.toml','',d)} \
+            ${@bb.utils.contains('PARSEC_PROVIDER','PKCS11','file://init_pkcs11_slots.sh','',d)} \
+            ${@bb.utils.contains('PARSEC_PROVIDER','PKCS11','file://01-tee.rules','',d)} \
            "
 
 BPN = "parsec-service"
@@ -17,7 +20,11 @@ CARGO_BUILD_FLAGS += "${CARGO_EXTRA_FLAGS} --features cryptoki/generate-bindings
 INITSCRIPT_NAME = "parsec"
 INITSCRIPT_PARAMS = "defaults"
 SYSTEMD_SERVICE_${PN} = "parsec.service"
-FILES_${PN} = "/usr /usr/bin /etc/parsec/*"
+FILES_${PN} = "/usr \
+               /usr/bin \
+               /etc/parsec/config.toml \
+               ${@bb.utils.contains('PARSEC_PROVIDER','PKCS11','/etc/udev/rules.d/01-tee.rules','',d)} \
+               "
 
 cargo_do_install_append () {
     install -d ${D}${bindir}
@@ -26,14 +33,33 @@ cargo_do_install_append () {
 }
 
 do_install_append () {
-    install -d ${D}${sysconfdir}/parsec
-    install -m 0600 ${WORKDIR}/config.toml ${D}${sysconfdir}/parsec
+
+    if [ "${PARSEC_PROVIDER}" = "SOFTWARE_TPM" ]; then
+        install -d ${D}${sysconfdir}/parsec
+        install -m 0600 ${WORKDIR}/config-tpm.toml ${D}${sysconfdir}/parsec/config.toml
+    fi
+
+    if [ "${PARSEC_PROVIDER}" = "PKCS11" ]; then
+        install -d ${D}${sysconfdir}/parsec
+        install -m 0600 ${WORKDIR}/config-pkcs11.toml ${D}${sysconfdir}/parsec/config.toml
+
+        install -d ${D}${bindir}
+        install -m 0700 ${WORKDIR}/init_pkcs11_slots.sh ${D}${bindir}/init_pkcs11_slots.sh
+
+        install -d ${D}${sysconfdir}/udev/rules.d
+        install -m 0644 ${WORKDIR}/01-tee.rules ${D}${sysconfdir}/udev/rules.d
+    fi
 
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${S}/systemd-daemon/parsec.service ${D}${systemd_unitdir}/system
 
-    sed -i -e 's,WorkingDirectory=/home/parsec/,WorkingDirectory=/userdata/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
+    sed -i -e 's,WorkingDirectory=/home/parsec/,WorkingDirectory=/userdata,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=mkdir -m 0750 -p /run/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
+    if [ "${PARSEC_PROVIDER}" = "PKCS11" ]; then
+        sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=+chown parsec /userdata/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
+        sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=+mkdir -m 0700 -p /userdata/parsec,g' ${D}${systemd_unitdir}/system/parsec.service
+        sed -i -e 's,\[Service\],\[Service\]\nExecStartPre=+/usr/bin/init_pkcs11_slots.sh,g' ${D}${systemd_unitdir}/system/parsec.service
+    fi
     sed -i -e 's,\[Service\],\[Service\]\nRestartSec=5s,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nRestart=always,g' ${D}${systemd_unitdir}/system/parsec.service
     sed -i -e 's,\[Service\],\[Service\]\nUser=parsec,g' ${D}${systemd_unitdir}/system/parsec.service

--- a/recipes-parsec/parsec-service/parsec-service/01-tee.rules
+++ b/recipes-parsec/parsec-service/parsec-service/01-tee.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tee", MODE="0660", OWNER="root", GROUP="parsec" TAG+="systemd", ENV{SYSTEMD_WANTS}+="tee-supplicant.service"

--- a/recipes-parsec/parsec-service/parsec-service/config-pkcs11.toml
+++ b/recipes-parsec/parsec-service/parsec-service/config-pkcs11.toml
@@ -14,10 +14,13 @@ auth_type = "UnixPeerCredentials"
 [[key_manager]]
 name = "on-disk-manager"
 manager_type = "OnDisk"
-store_path = "./mappings"
+store_path = "/userdata/parsec/mappings"
 
 [[provider]]
-provider_type = "Tpm"
+provider_type = "Pkcs11"
 key_info_manager = "on-disk-manager"
-tcti = "mssim"
-owner_hierarchy_auth = "hex:74706d5f70617373" # "tpm_pass" in hex
+library_path = "/usr/lib/libsks.so.0"
+
+slot_number = 0
+user_pin = "87654321"
+

--- a/recipes-parsec/parsec-service/parsec-service/config-tpm.toml
+++ b/recipes-parsec/parsec-service/parsec-service/config-tpm.toml
@@ -1,0 +1,23 @@
+[core_settings]
+log_level = "trace"
+log_error_details = true
+
+[listener]
+listener_type = "DomainSocket"
+# The timeout needs to be smaller than the test client timeout (five seconds) as it is testing
+# that the service does not hang for very big values of body or authentication length.
+timeout = 3000 # in milliseconds
+
+[authenticator]
+auth_type = "UnixPeerCredentials"
+
+[[key_manager]]
+name = "on-disk-manager"
+manager_type = "OnDisk"
+store_path = "/userdata/parsec/mappings"
+
+[[provider]]
+provider_type = "Tpm"
+key_info_manager = "on-disk-manager"
+tcti = "mssim"
+owner_hierarchy_auth = "hex:74706d5f70617373" # "tpm_pass" in hex

--- a/recipes-parsec/parsec-service/parsec-service/init_pkcs11_slots.sh
+++ b/recipes-parsec/parsec-service/parsec-service/init_pkcs11_slots.sh
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+# Work out how many slots are present, and how many are uninitialised.
+# If none of them are initialised then got ahead and initialise them.
+
+MODULE=/usr/lib/libsks.so.0
+SO_PIN=12345678
+PIN=87654321
+
+num_slots=$(pkcs11-tool --module $MODULE --list-slots | grep -c "^Slot")
+num_unintialized_slots=$(pkcs11-tool --module $MODULE --list-slots | grep -c "uninitialized")
+
+if [ $num_slots -gt 0 ]; then
+    if [ $num_unintialized_slots -eq $num_slots ]; then
+        pkcs11-tool --module $MODULE --init-token --label "parsec" --so-pin ${SO_PIN}
+        pkcs11-tool --module $MODULE --init-pin --so-pin ${SO_PIN} --pin ${PIN}
+    fi
+fi
+
+

--- a/recipes-parsec/parsec-service/parsec-service_0.7.2.inc
+++ b/recipes-parsec/parsec-service/parsec-service_0.7.2.inc
@@ -140,6 +140,7 @@ SRC_URI += " \
     crate://crates.io/zeroize/1.2.0 \
     crate://crates.io/zeroize_derive/1.0.1 \
     file://cryptoki.patch \
+    file://pkcs11_1.patch \
 "
 
 LIC_FILES_CHKSUM = " \

--- a/recipes-security/optee/optee-os-fio_3.10.0.bbappend
+++ b/recipes-security/optee/optee-os-fio_3.10.0.bbappend
@@ -1,0 +1,12 @@
+SUMMARY = "OP-TEE Trusted OS"
+DESCRIPTION = "Open Portable Trusted Execution Environment - Trusted side of the TEE"
+HOMEPAGE = "https://www.op-tee.org/"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
+
+EXTRA_OEMAKE_remove = "CFG_TEE_CORE_LOG_LEVEL=2"
+EXTRA_OEMAKE_remove = "CFG_TEE_TA_LOG_LEVEL=2"
+
+#EXTRA_OEMAKE += " CFG_TEE_CORE_LOG_LEVEL=0 CFG_TEE_TA_LOG_LEVEL=0"
+


### PR DESCRIPTION
Added the PKCS11 provider as an alternative to the SW TPM provider.

The provider to be used is controlled using the
PARSEC_PROVIDER variable in local.conf

This can either be SOFTWARE_TPM or PKCS11.

The relevant files will then be selected based upon that.